### PR TITLE
Update README.md - add DeleteItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ the required IAM Policy is as follows:
                 "dynamodb:CreateTable",
                 "dynamodb:UpdateTimeToLive",
                 "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
                 "dynamodb:DescribeTable",
                 "dynamodb:GetItem",
                 "dynamodb:UpdateItem"


### PR DESCRIPTION
is not authorized to perform: dynamodb:DeleteItem on resource: ... because no identity-based policy allows the dynamodb:DeleteItem action

DeleteItem is also required