### PR TITLE
Enhanced Lock Request Handling with TTL Consideration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+.aider*
+.env

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![Latest GitHub release](https://img.shields.io/github/release/mashiike/setddblock.svg)
 ![Github Actions test](https://github.com/mashiike/setddblock/workflows/Test/badge.svg?branch=main)
-[![Go Report Card](https://goreportcard.com/badge/mashiike/setddblock)](https://goreportcard.com/report/mashiike/setddblock) 
+[![Go Report Card](https://goreportcard.com/badge/mashiike/setddblock)](https://goreportcard.com/report/mashiike/setddblock)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/mashiike/setddblock/blob/master/LICENSE)
 [![Documentation](https://godoc.org/github.com/mashiike/setddblock?status.svg)](https://godoc.org/github.com/mashiike/setddblock)
 
 setddblock is setlock like command line tool with [AWS DynamoDB](https://aws.amazon.com/dynamodb/)
 
-## Usage 
+## Usage
 
 ```console
 $ setddblock -xN ddb://ddb_lock_table/lock_item_id your_command
@@ -32,13 +32,13 @@ Flags:
   --region string
         aws region
   --timeout string
-        set command timeout
+        set command timeout (e.g., 30s, 1m, 2h)
   --version
         show version
 ```
 
 the required IAM Policy is as follows:
-```json 
+```json
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -61,7 +61,7 @@ the required IAM Policy is as follows:
 ```
 
 If the lock table has already been created, `dynamodb:CreateTable` and `dynamodb:UpdateTimeToLive` are not required.
-## Install 
+## Install
 
 ### binary packages
 
@@ -81,7 +81,7 @@ $ brew install mashiike/tap/setddblock
 ```go
 l, err := setddblock.New("ddb://ddb_lock_table/lock_item_id")
 if err != nil {
-	// ...
+  // ...
 }
 func () {
     l.Lock()
@@ -90,10 +90,24 @@ func () {
 }()
 ```
 
-Note: If Lock or Unlock fails, for example because you can't connect to DynamoDB, it will panic.  
+Note: If Lock or Unlock fails, for example because you can't connect to DynamoDB, it will panic.
       If you don't want it to panic, use `LockWithError()` and `UnlockWithErr()`. Alternatively, use the `WithNoPanic` option.
 
-more infomation see [go doc](https://godoc.org/github.com/mashiike/setddblock).
+## TTL Expiration
+
+The `setddblock` tool now supports TTL (Time-To-Live) expiration for locks. This feature ensures that locks are automatically released after a specified duration, preventing stale locks from persisting indefinitely. If `setddblock` isn't run before the TTL expires, DynamoDB will eventually purge the stale item.
+
+### How TTL Works
+
+- When a lock is acquired, a TTL is set on the lock item in DynamoDB.
+- If a locked process dies and heartbeats stop updating the TTL, the lock will automatically expire and be released after the TTL duration, allowing other processes to acquire the lock.
+
+### TTL Configuration
+
+- The TTL is automatically calculated based on the lease duration set with the `WithLeaseDuration` option.
+- The TTL attribute is automatically set when the lock table is created and is updated by the heartbeat of a running locked process.
+
+For more information, see [go doc](https://godoc.org/github.com/mashiike/setddblock).
 ## License
 
 see [LICENSE](https://github.com/mashiike/setddblock/blob/master/LICENSE) file.

--- a/cmd/setddblock/main.go
+++ b/cmd/setddblock/main.go
@@ -42,7 +42,7 @@ func _main() int {
 	flag.BoolVar(&versionFlag, "version", false, "show version")
 	flag.StringVar(&endpoint, "endpoint", "", "If you switch remote, set AWS DynamoDB endpoint url.")
 	flag.StringVar(&region, "region", "", "aws region")
-	flag.StringVar(&timeout, "timeout", "", "set command timeout")
+	flag.StringVar(&timeout, "timeout", "", "set command timeout (e.g., 30s, 1m, 2h)")
 
 	args := make([]string, 1, len(os.Args))
 	args[0] = os.Args[0]
@@ -143,7 +143,7 @@ func _main() int {
 		return 6
 	}
 	if !lockGranted {
-		logger.Println("[warn][setddblock] lock was not granted")
+		logger.Printf("[warn][setddblock] lock was not granted for item_id=%s in table_name=%s at %s", locker.ItemID(), locker.TableName(), time.Now().Format(time.RFC3339))
 		if x && !X {
 			return 0
 		}

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -218,8 +218,8 @@ func (output *lockOutput) String() string {
 	)
 }
 
-func (svc *dynamoDBService) AquireLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
-	svc.logger.Printf("[debug][setddblock] AquireLock for table_name=%s, item_id=%s, lease_duration=%s, revision=%s, prev_revision=%v at %s", parms.TableName, parms.ItemID, parms.LeaseDuration, parms.Revision, parms.PrevRevision, time.Now().Format(time.RFC3339))
+func (svc *dynamoDBService) AcquireLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
+	svc.logger.Printf("[debug][setddblock] AcquireLock for table_name=%s, item_id=%s, lease_duration=%s, revision=%s, prev_revision=%v at %s", parms.TableName, parms.ItemID, parms.LeaseDuration, parms.Revision, parms.PrevRevision, time.Now().Format(time.RFC3339))
 	var ret *lockOutput
 	var err error
 	if parms.PrevRevision == nil {
@@ -238,8 +238,7 @@ func (svc *dynamoDBService) AquireLock(ctx context.Context, parms *lockInput) (*
 	for retrier.Continue() {
 		ret, err = svc.putItemForLock(ctx, parms)
 		if err != errMaybeRaceDeleted {
-			if err == nil {
-			} else {
+			if err != nil {
 				svc.logger.Printf("[error][setddblock] failed to acquire lock after retry: %s", err)
 			}
 			return ret, err

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -77,7 +77,7 @@ func (svc *dynamoDBService) waitLockTableActive(ctx context.Context, tableName s
 		if err == nil && exists {
 			return nil
 		}
-		svc.logger.Println("[debug][setddblock] retry lock table exists untile table active")
+		svc.logger.Println("[debug][setddblock] retry lock until table active, table exists")
 	}
 	if err == nil {
 		return fmt.Errorf("table not active")
@@ -91,19 +91,22 @@ func (svc *dynamoDBService) LockTableExists(ctx context.Context, tableName strin
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "ResourceNotFoundException") {
+			svc.logger.Printf("[debug][setddblock] lock not granted for table_name=%s", tableName)
 			return false, nil
 		}
 		return false, err
 	}
-	svc.logger.Printf("[debug][setddblock] table status is %s", table.Table.TableStatus)
-	if table.Table.TableStatus == types.TableStatusActive || table.Table.TableStatus == types.TableStatusUpdating {
+	svc.logger.Printf("[debug][setddblock] table `%s` status is %s", tableName, table.Table.TableStatus)
+	exists := table.Table.TableStatus == types.TableStatusActive || table.Table.TableStatus == types.TableStatusUpdating
+	svc.logger.Printf("[debug][setddblock] lock table `%s` exists = %v", tableName, exists)
+	if exists {
 		return true, nil
 	}
 	return false, nil
 }
 
 func (svc *dynamoDBService) CreateLockTable(ctx context.Context, tableName string) error {
-	svc.logger.Printf("[debug][setddblock] try create table %s", tableName)
+	svc.logger.Printf("[debug][setddblock] try - create table `%s`", tableName)
 	output, err := svc.client.CreateTable(ctx, &dynamodb.CreateTableInput{
 		TableName: &tableName,
 		AttributeDefinitions: []types.AttributeDefinition{
@@ -129,11 +132,11 @@ func (svc *dynamoDBService) CreateLockTable(ctx context.Context, tableName strin
 		}
 		return err
 	}
-	svc.logger.Printf("[debug][setddblock] success create table %s", *output.TableDescription.TableArn)
+	svc.logger.Printf("[debug][setddblock] success - create table `%s`", *output.TableDescription.TableArn)
 	if err := svc.waitLockTableActive(ctx, tableName); err != nil {
 		return err
 	}
-	svc.logger.Printf("[debug][setddblock] try update time to live `%s`", tableName)
+	svc.logger.Printf("[debug][setddblock] try - update TTL `%s`", tableName)
 	_, err = svc.client.UpdateTimeToLive(ctx, &dynamodb.UpdateTimeToLiveInput{
 		TableName: &tableName,
 		TimeToLiveSpecification: &types.TimeToLiveSpecification{
@@ -144,7 +147,7 @@ func (svc *dynamoDBService) CreateLockTable(ctx context.Context, tableName strin
 	if err != nil {
 		return err
 	}
-	svc.logger.Printf("[debug][setddblock] success update time to live `%s`", tableName)
+	svc.logger.Printf("[debug][setddblock] success - update TTL `%s`", tableName)
 	return nil
 }
 
@@ -216,7 +219,7 @@ func (output *lockOutput) String() string {
 }
 
 func (svc *dynamoDBService) AquireLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
-	svc.logger.Printf("[debug][setddblock] AquireLock %s", parms)
+	svc.logger.Printf("[debug][setddblock] AquireLock for table_name=%s, item_id=%s, lease_duration=%s, revision=%s, prev_revision=%v at %s", parms.TableName, parms.ItemID, parms.LeaseDuration, parms.Revision, parms.PrevRevision, time.Now().Format(time.RFC3339))
 	var ret *lockOutput
 	var err error
 	if parms.PrevRevision == nil {
@@ -228,29 +231,35 @@ func (svc *dynamoDBService) AquireLock(ctx context.Context, parms *lockInput) (*
 		return ret, nil
 	}
 	if err != errMaybeRaceDeleted {
+		svc.logger.Printf("[error][setddblock] failed to acquire lock: %s", err)
 		return nil, err
 	}
 	retrier := retryPolicy.Start(ctx)
 	for retrier.Continue() {
-		svc.logger.Printf("[debug][setddblock] race retry put item or get item")
 		ret, err = svc.putItemForLock(ctx, parms)
 		if err != errMaybeRaceDeleted {
+			if err == nil {
+			} else {
+				svc.logger.Printf("[error][setddblock] failed to acquire lock after retry: %s", err)
+			}
 			return ret, err
 		}
 	}
+	svc.logger.Printf("[error][setddblock] failed to acquire lock after all retries: %s", err)
 	return nil, err
 }
 
 func (svc *dynamoDBService) putItemForLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
 	item, nextHeartbeatLimit := parms.Item()
-	svc.logger.Printf("[debug][setddblock] try put item to ddb")
+	svc.logger.Printf("[debug][setddblock] try - put item in ddb")
 	_, err := svc.client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName:           &parms.TableName,
 		Item:                item,
 		ConditionExpression: aws.String("attribute_not_exists(ID)"),
 	})
 	if err == nil {
-		svc.logger.Printf("[debug][setddblock] lock granted")
+		_, ttl := parms.caluTime()
+		svc.logger.Printf("[debug][setddblock] lock granted with TTL: %d", ttl.Unix())
 		return &lockOutput{
 			LockGranted:        true,
 			LeaseDuration:      parms.LeaseDuration,
@@ -266,7 +275,7 @@ func (svc *dynamoDBService) putItemForLock(ctx context.Context, parms *lockInput
 }
 
 func (svc *dynamoDBService) getItemForLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
-	svc.logger.Printf("[debug][setddblock] try get item table_name=%s, item_id=%s", parms.TableName, parms.ItemID)
+	svc.logger.Printf("[debug][setddblock] try - get item table_name=%s, item_id=%s", parms.TableName, parms.ItemID)
 	output, err := svc.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: &parms.TableName,
 		Key: map[string]types.AttributeValue{
@@ -280,7 +289,8 @@ func (svc *dynamoDBService) getItemForLock(ctx context.Context, parms *lockInput
 	if err != nil {
 		return nil, err
 	}
-	svc.logger.Println("[debug][setddblock] get item success")
+	_, ttl := parms.caluTime()
+	svc.logger.Printf("[debug][setddblock] success - get item for table_name=%s, item_id=%s, TTL: %d, current_time=%d", parms.TableName, parms.ItemID, ttl.Unix(), time.Now().Unix())
 	n, ok := readAttributeValueMemberN(output.Item, "LeaseDuration")
 	if !ok {
 		return nil, errMaybeRaceDeleted
@@ -289,6 +299,21 @@ func (svc *dynamoDBService) getItemForLock(ctx context.Context, parms *lockInput
 	revision, ok := readAttributeValueMemberS(output.Item, "Revision")
 	if !ok || revision == "" {
 		return nil, errMaybeRaceDeleted
+	}
+
+	ttlValue, ok := readAttributeValueMemberN(output.Item, "ttl")
+	if !ok {
+		return nil, errMaybeRaceDeleted
+	}
+
+	if time.Now().Unix() > ttlValue {
+		svc.logger.Printf("[debug][setddblock] TTL has expired for item_id=%s, TTL=%d, current_time=%d, table_name=%s", parms.ItemID, ttlValue, time.Now().Unix(), parms.TableName)
+		return &lockOutput{
+			LockGranted:        true,
+			LeaseDuration:      leaseDuration,
+			Revision:           revision,
+			NextHeartbeatLimit: time.Now().Add(leaseDuration).Truncate(time.Millisecond),
+		}, nil
 	}
 
 	return &lockOutput{
@@ -328,10 +353,10 @@ func readAttributeValueMemberS(item map[string]types.AttributeValue, key string)
 }
 
 func (svc *dynamoDBService) updateItemForLock(ctx context.Context, parms *lockInput) (*lockOutput, error) {
-	svc.logger.Printf("[debug][setddblock] try update item to ddb")
+	svc.logger.Printf("[debug][setddblock] try - update item in ddb")
 	ret, err := svc.updateItem(ctx, parms)
 	if err == nil {
-		svc.logger.Printf("[debug][setddblock] success update item to ddb")
+		svc.logger.Printf("[debug][setddblock] success - update item in ddb")
 		svc.logger.Printf("[debug][setddblock] lock granted")
 		return ret, nil
 	}
@@ -419,7 +444,7 @@ func (svc *dynamoDBService) ReleaseLock(ctx context.Context, parms *lockInput) e
 }
 
 func (svc *dynamoDBService) deleteItemForUnlock(ctx context.Context, parms *lockInput) error {
-	svc.logger.Printf("[debug][setddblock] try delete item to ddb")
+	svc.logger.Printf("[debug][setddblock] try - delete item to ddb")
 	_, err := svc.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
 		TableName: &parms.TableName,
 		Key: map[string]types.AttributeValue{
@@ -435,7 +460,7 @@ func (svc *dynamoDBService) deleteItemForUnlock(ctx context.Context, parms *lock
 		},
 	})
 	if err == nil {
-		svc.logger.Printf("[debug][setddblock] success delete item to ddb")
+		svc.logger.Printf("[debug][setddblock] success - delete item from ddb")
 		return nil
 	}
 	if strings.Contains(err.Error(), "ConditionalCheckFailedException") {

--- a/locker.go
+++ b/locker.go
@@ -113,14 +113,14 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	l.logger.Println("[debug][setddblock] try - aquire lock")
+	l.logger.Println("[debug][setddblock] try - acquire lock")
 	input := &lockInput{
 		TableName:     l.tableName,
 		ItemID:        l.itemID,
 		LeaseDuration: l.leaseDuration,
 		Revision:      rev,
 	}
-	lockResult, err := l.svc.AquireLock(ctx, input)
+	lockResult, err := l.svc.AcquireLock(ctx, input)
 	if err != nil {
 		return false, err
 	}
@@ -130,7 +130,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 	if lockResult == nil {
-		l.logger.Printf("[debug][setddblock] aquire lock result is nil for table_name=%s, item_id=%s", l.tableName, l.itemID)
+		l.logger.Printf("[debug][setddblock] acquire lock result is nil for table_name=%s, item_id=%s", l.tableName, l.itemID)
 		return false, nil
 	}
 	if !lockResult.LockGranted && !l.delay {
@@ -138,7 +138,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 	}
 	for !lockResult.LockGranted {
 		sleepTime := time.Until(lockResult.NextHeartbeatLimit)
-		l.logger.Printf("[debug][setddblock] wait for next aquire lock until %s (%s)", lockResult.NextHeartbeatLimit, sleepTime)
+		l.logger.Printf("[debug][setddblock] wait for next acquire lock until %s (%s)", lockResult.NextHeartbeatLimit, sleepTime)
 		select {
 		case <-ctx.Done():
 			return false, ctx.Err()
@@ -149,7 +149,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		lockResult, err = l.svc.AquireLock(ctx, input)
+		lockResult, err = l.svc.AcquireLock(ctx, input)
 		if err != nil {
 			return false, err
 		}
@@ -218,7 +218,7 @@ func (l *DynamoDBLocker) Lock() {
 }
 
 //UnlockWithErr unlocks. Delete DynamoDB items
-func (l *DynamoDBLocker) UnlockWithErr(ctx context.Context) error {
+func (l *DynamoDBLocker) UnlockWithErr(_ context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.logger.Println("[debug][setddblock] start - UnlockWithErr")
@@ -231,6 +231,7 @@ func (l *DynamoDBLocker) UnlockWithErr(ctx context.Context) error {
 	l.logger.Println("[debug][setddblock] end - UnlockWithErr")
 	return nil
 }
+
 
 //Unlock for implements sync.Locker
 func (l *DynamoDBLocker) Unlock() {

--- a/locker.go
+++ b/locker.go
@@ -28,6 +28,16 @@ type DynamoDBLocker struct {
 	defaultCtx    context.Context
 }
 
+// ItemID returns the item ID of the lock.
+func (l *DynamoDBLocker) ItemID() string {
+	return l.itemID
+}
+
+// TableName returns the table name of the lock.
+func (l *DynamoDBLocker) TableName() string {
+	return l.tableName
+}
+
 //New returns *DynamoDBLocker
 func New(urlStr string, optFns ...func(*Options)) (*DynamoDBLocker, error) {
 	u, err := url.Parse(urlStr)
@@ -84,7 +94,7 @@ func (l *DynamoDBLocker) generateRevision() (string, error) {
 func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.logger.Println("[debug][setddblock] start LockWithErr")
+	l.logger.Println("[debug][setddblock] start - LockWithErr")
 	if l.locked {
 		return true, errors.New("aleady lock granted")
 	}
@@ -103,7 +113,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	l.logger.Println("[debug][setddblock] try aquire lock")
+	l.logger.Println("[debug][setddblock] try - aquire lock")
 	input := &lockInput{
 		TableName:     l.tableName,
 		ItemID:        l.itemID,
@@ -114,7 +124,15 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	l.logger.Println("[debug][setddblock] aquire lock reqult", lockResult)
+	if lockResult == nil {
+		// Lock is considered expired due to TTL
+		l.logger.Printf("[debug][setddblock] lock expired due to TTL for item_id=%s, table_name=%s, current_time=%s", l.itemID, l.tableName, time.Now().Format(time.RFC3339))
+		return false, nil
+	}
+	if lockResult == nil {
+		l.logger.Printf("[debug][setddblock] aquire lock result is nil for table_name=%s, item_id=%s", l.tableName, l.itemID)
+		return false, nil
+	}
 	if !lockResult.LockGranted && !l.delay {
 		return false, nil
 	}
@@ -131,14 +149,13 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		l.logger.Printf("[debug][setddblock] retry aquire lock until %s", input)
 		lockResult, err = l.svc.AquireLock(ctx, input)
 		if err != nil {
 			return false, err
 		}
 		l.logger.Printf("[debug][setddblock] now revision %s", lockResult.Revision)
 	}
-	l.logger.Println("[debug][setddblock] success lock granted")
+	l.logger.Println("[debug][setddblock] success - lock granted")
 	l.locked = true
 	l.unlockSignal = make(chan struct{})
 	l.wg = sync.WaitGroup{}
@@ -154,13 +171,13 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 				l.logger.Printf("[warn][setddblock] lock result is nil last error: %s", l.lastError)
 			}
 
-			l.logger.Println("[debug][setddblock] finish background heartbeet")
+			l.logger.Printf("[debug][setddblock] finish background heartbeat for item_id=%s, table_name=%s at %s", l.itemID, l.tableName, time.Now().Format(time.RFC3339))
 			l.wg.Done()
 		}()
 		nextHeartbeatTime := lockResult.NextHeartbeatLimit.Add(-time.Duration(float64(lockResult.LeaseDuration) * 0.2))
 		for {
 			sleepTime := time.Until(nextHeartbeatTime)
-			l.logger.Printf("[debug][setddblock] wait for next heartbeet time until %s (%s)", nextHeartbeatTime, sleepTime)
+			l.logger.Printf("[debug][setddblock] wait for next heartbeat time for item_id=%s, table_name=%s until %s (%s) at %s", l.itemID, l.tableName, nextHeartbeatTime, sleepTime, time.Now().Format(time.RFC3339))
 			select {
 			case <-ctx.Done():
 				return
@@ -168,7 +185,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 				return
 			case <-time.After(sleepTime):
 			}
-			l.logger.Println("[debug][setddblock] try send heartbeet")
+			l.logger.Println("[debug][setddblock] try send heartbeat")
 			input.PrevRevision = &lockResult.Revision
 			input.Revision, err = l.generateRevision()
 			if err != nil {
@@ -185,7 +202,7 @@ func (l *DynamoDBLocker) LockWithErr(ctx context.Context) (bool, error) {
 			nextHeartbeatTime = lockResult.NextHeartbeatLimit.Add(-time.Duration(float64(lockResult.LeaseDuration) * 0.2))
 		}
 	}()
-	l.logger.Println("[debug][setddblock] end LockWithErr")
+	l.logger.Println("[debug][setddblock] end -LockWithErr")
 	return true, nil
 }
 
@@ -204,14 +221,14 @@ func (l *DynamoDBLocker) Lock() {
 func (l *DynamoDBLocker) UnlockWithErr(ctx context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.logger.Println("[debug][setddblock] start UnlockWithErr")
+	l.logger.Println("[debug][setddblock] start - UnlockWithErr")
 	if !l.locked {
 		return errors.New("not lock granted")
 	}
 	close(l.unlockSignal)
 	l.locked = false
 	l.wg.Wait()
-	l.logger.Println("[debug][setddblock] end UnlockWithErr")
+	l.logger.Println("[debug][setddblock] end - UnlockWithErr")
 	return nil
 }
 

--- a/locker_test.go
+++ b/locker_test.go
@@ -47,13 +47,13 @@ func TestDDBLock(t *testing.T) {
 		}()
 		l.Lock()
 		defer l.Unlock()
-		t.Logf("f1 wroker_id = %d start", workerID)
+		t.Logf("Function f1: Worker ID = %d has started processing", workerID)
 		for i := 0; i < countMax; i++ {
 			total1 += 1
 			time.Sleep(10 * time.Millisecond)
 		}
 		lastTime1 = time.Now()
-		t.Logf("f1 wroker_id = %d finish", workerID)
+		t.Logf("Function f1: Worker ID = %d has finished processing", workerID)
 	}
 	f2 := func(workerID int, l sync.Locker) {
 		defer func() {
@@ -62,7 +62,7 @@ func TestDDBLock(t *testing.T) {
 		}()
 		l.Lock()
 		defer l.Unlock()
-		t.Logf("f2 wroker_id = %d start", workerID)
+		t.Logf("Function f2: Worker ID = %d has started processing", workerID)
 
 		for i := 0; i < countMax; i++ {
 			total2 += 1
@@ -70,7 +70,7 @@ func TestDDBLock(t *testing.T) {
 		}
 		lastTime2 = time.Now()
 
-		t.Logf("f2 wroker_id = %d finish", workerID)
+		t.Logf("Function f2: Worker ID = %d has finished processing", workerID)
 	}
 	for i := 0; i < workerNum; i++ {
 		wgEnd.Add(2)
@@ -106,8 +106,8 @@ func TestDDBLock(t *testing.T) {
 	t.Log(buf.String())
 	require.EqualValues(t, workerNum*countMax, total1)
 	require.EqualValues(t, workerNum*countMax, total2)
-	t.Logf("f1 last = %s", lastTime1)
-	t.Logf("f2 last = %s", lastTime2)
+	t.Logf("Function f1: Last execution time = %s", lastTime1)
+	t.Logf("Function f2: Last execution time = %s", lastTime2)
 	require.True(t, lastTime1.After(lastTime2))
 	require.False(t, strings.Contains(buf.String(), "[error]"))
 }

--- a/locker_ttl_test.go
+++ b/locker_ttl_test.go
@@ -1,0 +1,264 @@
+// locker-ttl_test.go
+
+package setddblock_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+  "log"
+
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/mashiike/setddblock"
+	"github.com/stretchr/testify/require"
+  "github.com/fujiwara/logutils"
+
+)
+
+/*
+TestTTLExpirationLock aims to verify that a DynamoDB-based lock expires as expected based on its TTL.
+The test follows these steps:
+1. Acquire an initial lock with a defined TTL (5 seconds).
+   - This lock is created using `DynamoDBLocker` and is intentionally left "unreleased" by killing the process to simulate a process crash.
+2. Check the lock's `TTL` and `Revision` attributes directly in DynamoDB.
+   - We use the AWS SDK to confirm the lock's TTL and verify that DynamoDB has recorded it.
+3. Continuously attempt to acquire the same lock before the TTL expires.
+   - Each acquisition attempt should fail until the TTL expires, confirming the lock is held until DynamoDB releases it.
+4. Once the TTL expires, validate that the lock can now be reacquired.
+   - This confirms that the time it took to reacquire the lock matches or exceeds the expected TTL, showing that the lock was released due to TTL expiration.
+*/
+
+func getItemDetails(client *dynamodb.Client, tableName, itemID string) (int64, string, error) {
+	result, err := client.GetItem(context.TODO(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]types.AttributeValue{
+			"ID": &types.AttributeValueMemberS{Value: itemID},
+		},
+	})
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to query DynamoDB: %w", err)
+	}
+
+	var ttl int64
+	if ttlAttr, ok := result.Item["ttl"].(*types.AttributeValueMemberN); ok {
+		ttl, err = strconv.ParseInt(ttlAttr.Value, 10, 64)
+		if err != nil {
+			return 0, "", fmt.Errorf("failed to parse TTL attribute: %w", err)
+		}
+	} else {
+		return 0, "", fmt.Errorf("TTL attribute is missing or has an unexpected type")
+	}
+
+	revision := ""
+	if revisionAttr, ok := result.Item["Revision"].(*types.AttributeValueMemberS); ok {
+		revision = revisionAttr.Value
+	} else {
+		return 0, "", fmt.Errorf("Revision attribute is missing or has an unexpected type")
+	}
+
+	return ttl, revision, nil
+}
+
+
+func setupDynamoDBClient(t *testing.T) *dynamodb.Client {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolver(
+		aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+			if service == dynamodb.ServiceID {
+				return aws.Endpoint{URL: dynamoDBURL}, nil
+			}
+			return aws.Endpoint{}, fmt.Errorf("unknown endpoint requested")
+		}),
+	))
+	require.NoError(t, err, "Failed to load AWS SDK config")
+	return dynamodb.NewFromConfig(cfg)
+}
+
+
+// toggle --debug style logging for setddblock
+// var enableLogging = false
+var enableLogging = true
+
+
+
+func tryAcquireLock(t *testing.T, logger *log.Logger, retryCount int) (bool, time.Time) {
+    options := []func(*setddblock.Options){
+        setddblock.WithEndpoint(dynamoDBURL),
+        setddblock.WithLeaseDuration(5 * time.Second),
+        setddblock.WithDelay(false),
+        setddblock.WithNoPanic(),
+    }
+    if enableLogging {
+        options = append(options, setddblock.WithLogger(logger))
+    }
+    locker, err := setddblock.New(
+        fmt.Sprintf("ddb://%s/%s", lockTableName, lockItemID),
+        options...,
+    )
+    require.NoError(t, err, "Failed to create locker for retry")
+
+    locker.Lock()
+
+    // I'm on the fence here - use 1 second precision or actual.
+    // the original ttl isn't a subsecond timestamp, so when we calculate it, it's not "real"
+    if locker.LastErr() == nil {
+        return true, time.Now() // Capture time of acquisition
+				// Capture acquisition time with whole-second precision
+		    // return true, time.Now().Truncate(time.Second)
+
+    }
+    return false, time.Time{}
+		// Capture acquisition time with whole-second precision
+    // return false, time.Now().Truncate(time.Second)
+}
+
+
+
+const (
+	leaseDuration   = 10 * time.Second
+	retryInterval   = 1 * time.Second
+	maxRetries      = 100
+	dynamoDBURL     = "http://localhost:8000"
+	lockItemID      = "lock_item_id"
+	lockTableName   = "test"
+)
+
+func setupLogger() *log.Logger {
+	logger := log.New(os.Stdout, "", log.LstdFlags|log.Lmicroseconds)
+	filter := &logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"debug", "warn", "error"},
+		MinLevel: "warn",
+		Writer:   os.Stdout,
+	}
+	if enableLogging {
+		filter.MinLevel = "debug"
+	}
+	logger.SetOutput(filter)
+	return logger
+}
+
+func acquireInitialLock(logger *log.Logger) {
+	locker, err := setddblock.New(
+		fmt.Sprintf("ddb://%s/%s", lockTableName, lockItemID),
+		setddblock.WithEndpoint(dynamoDBURL),
+		setddblock.WithLeaseDuration(leaseDuration),
+		setddblock.WithDelay(false),
+		setddblock.WithNoPanic(),
+	)
+	if enableLogging {
+		locker, err = setddblock.New(
+			fmt.Sprintf("ddb://%s/%s", lockTableName, lockItemID),
+			setddblock.WithEndpoint(dynamoDBURL),
+			setddblock.WithLeaseDuration(leaseDuration),
+			setddblock.WithDelay(false),
+			setddblock.WithNoPanic(),
+			setddblock.WithLogger(logger),
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create locker: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create locker: %v\n", err)
+		os.Exit(1)
+	}
+	locker.Lock()
+	fmt.Println(fmt.Sprintf("[%s] Initial lock acquired; simulating lock hold indefinitely.", time.Now().Format(time.RFC3339)))
+
+
+	select {} // Keep the process alive to simulate a lock hold
+}
+
+// Test function with process forking and cleanup
+func TestTTLExpirationLock(t *testing.T) {
+
+	var retryCount int
+  var actualAcquiredTime time.Time // Declare `actualAcquiredTime` at the top
+
+	// Use the debug variable to control logging level.
+	// This is set to false by default but can be toggled for more verbose output.
+	logger := setupLogger()
+
+	// Load AWS SDK DynamoDB client configuration
+	client := setupDynamoDBClient(t)
+
+	// Step 1: Check if we are in the main process or the forked process
+	if os.Getenv("FORKED") == "1" {
+		acquireInitialLock(logger)
+		return
+	}
+
+	// Step 2: Fork the process to acquire and hold the initial lock
+	t.Logf("[%s] Forking process to acquire initial lock.", time.Now().Format(time.RFC3339))
+	cmd := exec.Command(os.Args[0], "-test.run=TestTTLExpirationLock")
+	cmd.Env = append(os.Environ(), "FORKED=1")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start(), "Failed to fork process for lock acquisition")
+
+	// Allow the forked process time to acquire the lock
+	t.Logf("[%s] Waiting for forked process to acquire lock...", time.Now().Format(time.RFC3339))
+	time.Sleep(3 * time.Second)
+
+	// Step 3: Kill the forked process to simulate a crash
+	t.Logf("[%s] Killing forked process to simulate crash.", time.Now().Format(time.RFC3339))
+	require.NoError(t, cmd.Process.Kill(), "Failed to kill forked process")
+
+	// Confirm process termination
+	processState, err := cmd.Process.Wait()
+	if err != nil {
+		t.Fatalf("Failed to confirm process termination: %v", err)
+	}
+	t.Logf("[%s] Forked process terminated with status: %v", time.Now().Format(time.RFC3339), processState)
+
+	// Step 4: Log initial lock's TTL and revision from DynamoDB
+	initialTTL, initialRevision, err := getItemDetails(client, lockTableName, lockItemID)
+	require.NoError(t, err, "Failed to get item details")
+	expireTime := time.Unix(initialTTL, 0)
+
+	t.Logf("[%s] Initial: REVISION=%s, TTL=%d Now=%d Expires: %s",
+		time.Now().Format(time.RFC3339), initialRevision, initialTTL, time.Now().Unix(), expireTime.Format(time.RFC3339))
+
+	// Start retry loop
+	for retryCount < maxRetries {
+		retryCount++
+		t.Logf("[%s] [Retry #%d] Attempting lock acquisition.", time.Now().Format(time.RFC3339), retryCount)
+
+    // Capture lock status and acquisition time
+    lockAcquired, acquiredTime := tryAcquireLock(t, logger, retryCount)
+
+    if lockAcquired {
+        actualAcquiredTime = acquiredTime // Capture the exact acquisition time
+        t.Logf("[%s] Lock finally acquired at %d, original TTL: %d", acquiredTime.Format(time.RFC3339), acquiredTime.Unix(), expireTime.Unix())
+        break
+    }
+
+		// Check TTL to ensure it's stable and not being updated
+		currentTTL, currentRevision, err := getItemDetails(client, lockTableName, lockItemID)
+		if err == nil {
+			t.Logf("[%s] [Retry #%d] REVISION=%s, TTL=%d Now=%d Expires: %s",
+				time.Now().Format(time.RFC3339), retryCount, currentRevision, currentTTL,
+				time.Now().Unix(), time.Unix(currentTTL, 0).Format(time.RFC3339))
+
+		} else {
+			t.Logf("[Retry #%d] Failed to retrieve item details: %v", retryCount, err)
+		}
+
+		time.Sleep(retryInterval)
+	}
+
+	// Log duration between TTL expiration and successful lock acquisition
+	timeAfterTTL := actualAcquiredTime.Sub(expireTime)
+	t.Logf("[%s] Time between TTL expiration and lock acquisition: %v", time.Now().Format(time.RFC3339), timeAfterTTL)
+	require.LessOrEqual(t, timeAfterTTL.Seconds(), 3.0, "Time between TTL expiration and lock acquisition should not exceed 3 seconds")
+	require.GreaterOrEqual(t, actualAcquiredTime.Unix(), initialTTL, "Lock should only be acquired after TTL expiration")
+
+}

--- a/locker_ttl_test.go
+++ b/locker_ttl_test.go
@@ -69,8 +69,8 @@ func getItemDetails(client *dynamodb.Client, tableName, itemID string) (int64, s
 
 
 func setupDynamoDBClient(t *testing.T) *dynamodb.Client {
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolver(
-		aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithEndpointResolverWithOptions(
+		aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 			if service == dynamodb.ServiceID {
 				return aws.Endpoint{URL: dynamoDBURL}, nil
 			}
@@ -80,6 +80,7 @@ func setupDynamoDBClient(t *testing.T) *dynamodb.Client {
 	require.NoError(t, err, "Failed to load AWS SDK config")
 	return dynamodb.NewFromConfig(cfg)
 }
+
 
 
 // toggle --debug style logging for setddblock
@@ -171,7 +172,8 @@ func acquireInitialLock(logger *log.Logger) {
 		os.Exit(1)
 	}
 	locker.Lock()
-	fmt.Println(fmt.Sprintf("[%s] Initial lock acquired; simulating lock hold indefinitely.", time.Now().Format(time.RFC3339)))
+	fmt.Printf("[%s] Initial lock acquired; simulating lock hold indefinitely.\n", time.Now().Format(time.RFC3339))
+
 
 
 	select {} // Keep the process alive to simulate a lock hold

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Exit on error and unset variables
+set -eu
+
+# Set up environment variables
+export AWS_ACCESS_KEY_ID=dummy
+export AWS_SECRET_ACCESS_KEY=dummy
+export DYNAMODB_LOCAL_ENDPOINT=http://localhost:8000
+export AWS_DEFAULT_REGION=ap-northeast-1
+
+# Display usage information
+usage() {
+  echo "Usage: $0 [test_file]"
+  echo "Run all tests if no test file is specified."
+  echo "Options:"
+  echo "  -h, --help     Display this help message"
+}
+
+# Check if help is requested
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Invalid option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+fi
+
+# Check for a test file argument
+TEST_FILE="${1:-all}"
+
+# Start DynamoDB Local using Docker Compose
+echo "Starting DynamoDB Local..."
+docker-compose up -d ddb-local
+
+# Wait for DynamoDB Local to be ready
+echo "Waiting for DynamoDB Local to be ready..."
+until curl -s http://localhost:8000; do
+  sleep 1
+done
+echo "DynamoDB Local is ready."
+
+# Run tests and capture the exit code
+echo "Running tests for the setddblock package..."
+if [[ "$TEST_FILE" == "all" ]]; then
+  go test -v -race -timeout 30s ./... || test_status=$?
+else
+  go test -v -race -timeout 30s "$TEST_FILE" || test_status=$?
+fi
+
+# Default exit status to 0 if tests passed
+test_status="${test_status:-0}"
+
+# Stop DynamoDB Local
+echo "Stopping DynamoDB Local..."
+docker-compose down
+
+# Exit with the test command's status
+exit "$test_status"


### PR DESCRIPTION
- **TTL Consideration**: Updated the lock request logic to consider the TTL (Time-To-Live) attribute when determining lock availability. Previously, TTL was ignored during lock requests, relying solely on DynamoDB's eventual purge, which can occur at any time, typically within a few days of expiration. Now, the lock request process checks the TTL to ensure that locks are not granted if the TTL has not yet expired.
- **Testing Enhancements**: Added comprehensive tests to verify TTL expiration behavior and ensure locks are correctly released after TTL expiry. This includes simulating process crashes and verifying lock reacquisition.
- **Documentation Update**: Updated `README.md` to reflect changes in TTL handling, clarifying that TTL is automatically managed and no manual configuration is needed for the TTL attribute.
- **Code Refactoring**: Refactored code to improve readability and maintainability, including better logging and error handling.
- Added `go test` wrapper script (`run-tests.sh`) for easier local testing