### PR TITLE
Enhance CLI tool logging

### DIFF
--- a/locker.go
+++ b/locker.go
@@ -28,6 +28,11 @@ type DynamoDBLocker struct {
 	defaultCtx    context.Context
 }
 
+// GetLockDetails retrieves the lock details for the current item.
+func (l *DynamoDBLocker) GetLockDetails(ctx context.Context) (*LockDetails, error) {
+	return l.svc.GetLockDetails(ctx, l.tableName, l.itemID)
+}
+
 // ItemID returns the item ID of the lock.
 func (l *DynamoDBLocker) ItemID() string {
 	return l.itemID

--- a/locker_ttl_test.go
+++ b/locker_ttl_test.go
@@ -84,8 +84,8 @@ func setupDynamoDBClient(t *testing.T) *dynamodb.Client {
 
 
 // toggle --debug style logging for setddblock
-// var enableLogging = false
-var enableLogging = true
+// var enableDebug = false
+var enableDebug = true
 
 
 
@@ -96,7 +96,7 @@ func tryAcquireLock(t *testing.T, logger *log.Logger, retryCount int) (bool, tim
         setddblock.WithDelay(false),
         setddblock.WithNoPanic(),
     }
-    if enableLogging {
+    if enableDebug {
         options = append(options, setddblock.WithLogger(logger))
     }
     locker, err := setddblock.New(
@@ -138,7 +138,7 @@ func setupLogger() *log.Logger {
 		MinLevel: "warn",
 		Writer:   os.Stdout,
 	}
-	if enableLogging {
+	if enableDebug {
 		filter.MinLevel = "debug"
 	}
 	logger.SetOutput(filter)
@@ -153,7 +153,7 @@ func acquireInitialLock(logger *log.Logger) {
 		setddblock.WithDelay(false),
 		setddblock.WithNoPanic(),
 	)
-	if enableLogging {
+	if enableDebug {
 		locker, err = setddblock.New(
 			fmt.Sprintf("ddb://%s/%s", lockTableName, lockItemID),
 			setddblock.WithEndpoint(dynamoDBURL),


### PR DESCRIPTION
 * Add lock/release info log to ensure the user is always informed about lock status.
 * Include detailed information in lock failure logs, showing TTL, expiration, and revision to avoid manual investigation.
 * Introduce a simple CLI-based test in run-tests.sh to demonstrate logging changes during local testing.